### PR TITLE
Fix: ensure raw strings are safely escaped by default in SSDOM nodes

### DIFF
--- a/src/probo/components/base.py
+++ b/src/probo/components/base.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from collections import deque
 from typing import Dict, Union, Self, Any,Generator
 import inspect
-from probo.utility import ProboSourceString
+from probo.utility import ProboSourceString,markup_escape
 
 class ElementAttributeManipulator:
     """
@@ -465,14 +465,14 @@ class BaseHTMLElement(ABC):
         def _add_to_collector(target, item):
             if not use_list:
                 if isinstance(item, (list, deque)):
-                    return target + "".join((x if isinstance(x, ProboSourceString) else str(x)) for x in item)
-                return target + (item if isinstance(item, ProboSourceString) else str(item))
+                    return target + "".join((x if isinstance(x, ProboSourceString) else markup_escape(x)) for x in item)
+                return target + (item if isinstance(item, ProboSourceString) else markup_escape(item))
             else:
                 # If the item is already a collection, merge it (O(1) if deque)
                 if isinstance(item, (list, deque)):
                     target.extend(item)
                 else:
-                    target.append(item if isinstance(item, ProboSourceString) else str(item))
+                    target.append(item if isinstance(item, ProboSourceString) else markup_escape(item))
                 return target
 
         # 3. Process the content
@@ -492,11 +492,11 @@ class BaseHTMLElement(ABC):
             elif inspect.isgenerator(item):
                 print('xxxxx')
                 if use_list and use_deque:
-                    rendered = ( deque((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x,"render") else x.render() for x in item))
+                    rendered = ( deque((x if isinstance(x, ProboSourceString) else markup_escape(x)) if not hasattr(x,"render") else x.render() for x in item))
                 elif use_list and use_deque:
-                    rendered = ( list((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x,"render") else x.render() for x in item))
+                    rendered = ( list((x if isinstance(x, ProboSourceString) else markup_escape(x)) if not hasattr(x,"render") else x.render() for x in item))
                 else:
-                    rendered = ( ProboSourceString("".join((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x,"render") else x.render() for x in item)))
+                    rendered = ( ProboSourceString("".join((x if isinstance(x, ProboSourceString) else markup_escape(x)) if not hasattr(x,"render") else x.render() for x in item)))
 
             elif isinstance(item, Iterable) and not isinstance(
                 item, (str, bytes, deque)
@@ -511,20 +511,20 @@ class BaseHTMLElement(ABC):
                         if isinstance(sub_rendered, (list, deque)):
                             sub_collector.extend(sub_rendered)
                         else:
-                            sub_collector.append(sub_rendered if isinstance(sub_rendered, ProboSourceString) else str(sub_rendered))
+                            sub_collector.append(sub_rendered if isinstance(sub_rendered, ProboSourceString) else markup_escape(sub_rendered))
                     else:
-                        sub_collector.append(sub if isinstance(sub, ProboSourceString) else str(sub))
+                        sub_collector.append(sub if isinstance(sub, ProboSourceString) else markup_escape(sub))
                 rendered = sub_collector
 
             # Scenario C: Child is a raw value (String, Int, etc.)
             else:
-                rendered = item if isinstance(item, ProboSourceString) else str(item)
+                rendered = item if isinstance(item, ProboSourceString) else markup_escape(item)
 
             # Merge the rendered result into our main collector
             collector = _add_to_collector(collector, rendered)
 
         return collector
-
+        
     def _get_stream_content(self, batch: int = 50) -> Generator[str, None, None]:
         """
         The streaming engine: Iterates through children and yields HTML fragments.

--- a/src/probo/components/base.py
+++ b/src/probo/components/base.py
@@ -465,14 +465,14 @@ class BaseHTMLElement(ABC):
         def _add_to_collector(target, item):
             if not use_list:
                 if isinstance(item, (list, deque)):
-                    return target + "".join(map(str, item))
-                return target + str(item)
+                    return target + "".join((x if isinstance(x, ProboSourceString) else str(x)) for x in item)
+                return target + (item if isinstance(item, ProboSourceString) else str(item))
             else:
                 # If the item is already a collection, merge it (O(1) if deque)
                 if isinstance(item, (list, deque)):
                     target.extend(item)
                 else:
-                    target.append(str(item))
+                    target.append(item if isinstance(item, ProboSourceString) else str(item))
                 return target
 
         # 3. Process the content
@@ -492,11 +492,11 @@ class BaseHTMLElement(ABC):
             elif inspect.isgenerator(item):
                 print('xxxxx')
                 if use_list and use_deque:
-                    rendered = ( deque(ProboSourceString(x)if not hasattr(x,"render") else x.render() for x in item))
+                    rendered = ( deque((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x,"render") else x.render() for x in item))
                 elif use_list and use_deque:
-                    rendered = ( list(ProboSourceString(x)if not hasattr(x,"render") else x.render() for x in item))
+                    rendered = ( list((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x,"render") else x.render() for x in item))
                 else:
-                    rendered = ( ProboSourceString("".join(ProboSourceString(x)if not hasattr(x,"render") else x.render() for x in item)))
+                    rendered = ( ProboSourceString("".join((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x,"render") else x.render() for x in item)))
 
             elif isinstance(item, Iterable) and not isinstance(
                 item, (str, bytes, deque)
@@ -511,14 +511,14 @@ class BaseHTMLElement(ABC):
                         if isinstance(sub_rendered, (list, deque)):
                             sub_collector.extend(sub_rendered)
                         else:
-                            sub_collector.append(sub_rendered)
+                            sub_collector.append(sub_rendered if isinstance(sub_rendered, ProboSourceString) else str(sub_rendered))
                     else:
-                        sub_collector.append(str(sub))
+                        sub_collector.append(sub if isinstance(sub, ProboSourceString) else str(sub))
                 rendered = sub_collector
 
             # Scenario C: Child is a raw value (String, Int, etc.)
             else:
-                rendered = item
+                rendered = item if isinstance(item, ProboSourceString) else str(item)
 
             # Merge the rendered result into our main collector
             collector = _add_to_collector(collector, rendered)

--- a/src/probo/components/light_tags/node.py
+++ b/src/probo/components/light_tags/node.py
@@ -72,15 +72,22 @@ class LightNode:
                     collector.append(item.render(EL))
             elif inspect.isgenerator(item):
                 if EL.is_list and EL.use_deque:
-                    collector.extend( deque(ProboSourceString(x)if not hasattr(x,"render") else x.render() for x in item))
+                    collector.extend(
+                        deque((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x, "render") else x.render() for x in item)
+                    )
                 elif EL.is_list and not EL.use_deque:
-                    collector.extend( list(ProboSourceString(x)if not hasattr(x,"render") else x.render() for x in item))
+                    collector.extend(
+                        list((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x, "render") else x.render() for x in item)
+                    )
                 else:
-                    collector.extend( ProboSourceString("".join(ProboSourceString(x)if not hasattr(x,"render") else x.render() for x in item)))
+                    collector.extend(
+                        ProboSourceString("".join((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x, "render") else x.render() for x in item))
+                    )
             elif hasattr(item, "render"):
-                collector.append(ProboSourceString(item.render()))
+                rendered_item = item.render()
+                collector.append(rendered_item if isinstance(rendered_item, ProboSourceString) else str(rendered_item))
             else:
-                collector.append(ProboSourceString(str(item)))
+                collector.append(item if isinstance(item, ProboSourceString) else str(item))
         if EL.is_list or EL.is_list and EL.use_deque:
             return collector  # Return list of strings for the caller to join
         return ProboSourceString("".join(collector))

--- a/src/probo/components/light_tags/node.py
+++ b/src/probo/components/light_tags/node.py
@@ -1,6 +1,6 @@
 from typing import Generator, Any, Union, Optional
 from collections import deque
-from probo.utility import StreamManager,ProboSourceString
+from probo.utility import StreamManager,ProboSourceString,markup_escape
 import inspect
 
 class LightNode:
@@ -73,21 +73,21 @@ class LightNode:
             elif inspect.isgenerator(item):
                 if EL.is_list and EL.use_deque:
                     collector.extend(
-                        deque((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x, "render") else x.render() for x in item)
+                        deque((x if isinstance(x, ProboSourceString) else markup_escape(x)) if not hasattr(x, "render") else x.render() for x in item)
                     )
                 elif EL.is_list and not EL.use_deque:
                     collector.extend(
-                        list((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x, "render") else x.render() for x in item)
+                        list((x if isinstance(x, ProboSourceString) else markup_escape(x)) if not hasattr(x, "render") else x.render() for x in item)
                     )
                 else:
                     collector.extend(
-                        ProboSourceString("".join((x if isinstance(x, ProboSourceString) else str(x)) if not hasattr(x, "render") else x.render() for x in item))
+                        ProboSourceString("".join((x if isinstance(x, ProboSourceString) else markup_escape(x)) if not hasattr(x, "render") else x.render() for x in item))
                     )
             elif hasattr(item, "render"):
                 rendered_item = item.render()
-                collector.append(rendered_item if isinstance(rendered_item, ProboSourceString) else str(rendered_item))
+                collector.append(rendered_item if isinstance(rendered_item, ProboSourceString) else markup_escape(rendered_item))
             else:
-                collector.append(item if isinstance(item, ProboSourceString) else str(item))
+                collector.append(item if isinstance(item, ProboSourceString) else markup_escape(item))
         if EL.is_list or EL.is_list and EL.use_deque:
             return collector  # Return list of strings for the caller to join
         return ProboSourceString("".join(collector))


### PR DESCRIPTION
Fixes #19 

As discussed in the issue, this PR ensures that all raw strings passed into SSDOM nodes are safely HTML-escaped by default to prevent injection attacks.

### Changes Made
* **`BaseHtmlElement` (`src/probo/components/base.py`)**: Updated `_get_rendered_content` to apply strict `isinstance(..., ProboSourceString)` checks before merging items into the collector.
* **`LightNode` (`src/probo/components/light_tags/node.py`)**: Modified `_get_rendered_content` to apply the same strict type-checking logic across raw elements, components, and generators.
* **Default Escaping Enforced**: Replaced the blind `ProboSourceString` wrapping. If content is not explicitly flagged as a `ProboSourceString`, it is now safely cast to `str()`, ensuring the framework's internal escaping engine processes it.
* **Architecture Preserved**: Kept core class structures, original return types, and tag-rendering mechanics completely intact to avoid breaking any dependent tag classes, as requested.
