### PR TITLE
feat: add CustomElement with SSDOM integration and stream support

### DIFF
--- a/src/probo/components/custom_element.py
+++ b/src/probo/components/custom_element.py
@@ -1,0 +1,60 @@
+from collections import deque
+from typing import Any, Generator
+from probo.components.base import BaseHTMLElement
+from probo.components.node import ElementNodeMixin, ElementMutatorMixin
+from probo.utility import StreamManager
+
+class CustomElement(BaseHTMLElement, ElementNodeMixin, ElementMutatorMixin):
+    """Represents a Custom HTML element dynamically integrated into SSDOM."""
+    
+    __slots__ = ('tag', 'is_self_closing')
+
+    def __init__(self, tag_name: str, *content: Any, is_self_closing: bool=False, **attrs: Any):
+        #Initialize base class
+        super().__init__(*content,**attrs)
+        #Force uppercase as the default for the tag name
+        self.tag = tag_name.upper() 
+        self.is_self_closing = is_self_closing
+
+        ElementNodeMixin.__init__(self)
+        self._set_node_children(content)
+        ElementMutatorMixin.__init__(self)
+
+    def render(self) -> str:
+        '''
+        Blueprint:custom_element = Element(
+        ).set_attrs(**self.attributes).set_content(self.content).custom_element(self.tag).element'''
+        content = self._get_rendered_content()
+        return (
+            self.EL
+            .set_attrs(**self.attributes)
+            .set_content(content)
+            .custom_element(self.tag)
+            .element
+        )
+    
+    def stream(self, batch: int=50) -> Generator[str,None,None]:
+        '''
+        Blueprint:custom_element = Element(
+        ).set_attrs(**self.attributes).set_content(self.content).custom_element(self.tag).element'''
+        self.delegate_render_conditions(
+            use_list=True,
+        )
+
+        content_generator = self._get_stream_content(batch=batch)
+
+        element_info = (
+            self.EL
+            .set_attrs(**self.attributes)
+            .set_generator_content(content_generator)
+            .custom_element(self.tag)
+            .element
+        )
+
+        stream_manager = StreamManager(
+            element_info[0],
+            self.EL.stream(batch=batch),
+            element_info[-1],
+            chunk_size=batch,
+        )
+        yield from stream_manager

--- a/tests/components/test_custom_element.py
+++ b/tests/components/test_custom_element.py
@@ -1,0 +1,46 @@
+import pytest
+from probo.components.custom_element import CustomElement
+from probo.components.tag_classes.block_tags import DIV
+
+def test_custom_element_basic_render():
+    """Tests whether a custom tag with content generates the correct opening and closing HTML."""
+    elem = CustomElement('MY-TAG', 'Internal Text', id='test-id')
+    html = elem.render()
+    
+    assert '<my-tag' in html
+    assert 'id="test-id"' in html
+    assert 'Internal Text' in html
+    assert '</my-tag>' in html
+
+def test_custom_element_self_closing():
+    """Test that the is_self_closing parameter generates an empty, self-closing tag."""
+    elem = CustomElement('GITHUB', is_self_closing=True, url="https://github.com")
+    html = elem.render()
+    
+    assert '<github' in html
+    assert 'url="https://github.com"' in html
+
+def test_custom_element_ssdom_find():
+    """
+    Verify that the CustomElement is a real SSDOM node 
+    and that it can be found using the .find() method.
+    """
+    template = DIV(
+        CustomElement('GITHUB', is_self_closing=True)
+    )
+    
+    custom = template.find(lambda n: hasattr(n, 'tag') and n.tag == 'GITHUB')
+    
+    assert custom is not None
+    assert custom.tag == 'GITHUB'
+    assert custom.is_self_closing is True
+
+def test_custom_element_stream():
+    """Test that the custom tag supports streaming via generators."""
+    elem = CustomElement('STREAM-TAG', 'Async Content')
+    stream_generator = elem.stream()
+    html = "".join(list(stream_generator))
+    
+    assert '<stream-tag' in html
+    assert 'Async Content' in html
+    assert '</stream-tag>' in html


### PR DESCRIPTION
Here is the code for the new `CustomElement` class. I followed the suggestions from the issue to make sure it works perfectly with the SSDOM and the rest of the framework.

Here is a detailed list of what I did:

**1. SSDOM Integration**
I added `ElementNodeMixin` and `ElementMutatorMixin` to the class, and I used the `_set_node_children` method. Because of this, the custom tag is now a real node in the tree.

**2. Streaming Support**
I looked at the standard tags and added the `stream()` method using `StreamManager`. 

**3. Engine Compatibility**
I made sure the code matches the internal engine logic. For example, the `custom_element()` method now correctly takes the tag name as a positional argument. I also added the "Blueprint" comments in the code to keep the same style as the other tags.

**4. Testing**
I created a new test file: `tests/components/test_custom_element.py`. I wrote four tests to check:
* Basic rendering
* Self-closing tags (`is_self_closing=True`)
* Finding the element in the SSDOM tree
* Generator streaming
All the tests pass successfully.

Please review the code when you have time. If you want me to change, rewrite, or improve anything, just let me know and I will be happy to update the PR!

Closes #23 